### PR TITLE
Normalize plugin/preset ref arrays with single item

### DIFF
--- a/lib/reduceChains.js
+++ b/lib/reduceChains.js
@@ -90,7 +90,9 @@ function reduceOptions (chain, envName, pluginsAndPresets, dependencies, sources
     const lookup = pluginsAndPresets.get(config)
     const mapPluginOrPreset = (getEntry, ref) => {
       if (Array.isArray(ref)) {
-        return [mapPluginOrPreset(getEntry, ref[0]), ref[1]]
+        return ref.length === 1
+          ? mapPluginOrPreset(getEntry, ref[0])
+          : [mapPluginOrPreset(getEntry, ref[0]), ref[1]]
       }
 
       const entry = getEntry(ref)

--- a/test/Verifier.js
+++ b/test/Verifier.js
@@ -22,6 +22,7 @@ test.before(t => {
   for (const pkg of [
     fixture('compare', 'node_modules', 'env-plugin', 'package.json'),
     fixture('compare', 'node_modules', 'plugin', 'package.json'),
+    fixture('compare', 'node_modules', 'plugin-default-opts', 'package.json'),
     fixture('compare', 'node_modules', 'preset', 'package.json')
   ]) {
     promises.push(
@@ -86,6 +87,7 @@ test('cache is used when creating verifier', async t => {
   await result.createVerifier()
   for (const dependency of [
     fixture('compare', 'node_modules', 'plugin', 'index.js'),
+    fixture('compare', 'node_modules', 'plugin-default-opts', 'index.js'),
     fixture('compare', 'node_modules', 'preset', 'index.js')
   ]) {
     t.true(cache.dependencyHashes.has(dependency))
@@ -130,6 +132,7 @@ test('cacheKeysForCurrentEnv()', async t => {
   t.deepEqual(verifier.cacheKeysForCurrentEnv(), {
     dependencies: md5Hex([
       hashes[fixture('compare', 'node_modules', 'env-plugin', 'package.json')],
+      hashes[fixture('compare', 'node_modules', 'plugin-default-opts', 'package.json')],
       hashes[fixture('compare', 'node_modules', 'plugin', 'package.json')],
       hashes[fixture('compare', 'node_modules', 'preset', 'package.json')]
     ]),

--- a/test/fixtures/compare/.babelrc
+++ b/test/fixtures/compare/.babelrc
@@ -9,7 +9,8 @@
   env: {
     foo: {
       plugins: [
-        ['env-plugin', {label: 'plugin@babelrc.foo'}]
+        ['env-plugin', {label: 'plugin@babelrc.foo'}],
+        ['plugin-default-opts']
       ],
       presets: [
         ['preset', {label: 'preset@babelrc.foo'}]

--- a/test/fixtures/compare/node_modules/plugin-default-opts/index.js
+++ b/test/fixtures/compare/node_modules/plugin-default-opts/index.js
@@ -1,0 +1,12 @@
+'use strict'
+
+module.exports = babel => {
+  return {
+    visitor: {
+      ArrayExpression (path, state) {
+        const node = path.node
+        node.elements.push(babel.types.stringLiteral(JSON.stringify({'plugin-default-opts': state.opts})))
+      }
+    }
+  }
+}

--- a/test/fixtures/compare/node_modules/plugin-default-opts/package.json
+++ b/test/fixtures/compare/node_modules/plugin-default-opts/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "plugin-default-opts",
+  "version": "1.0.0",
+  "private": true,
+  "standard-engine": "@novemberborn/as-i-preach"
+}

--- a/test/main.js
+++ b/test/main.js
@@ -191,6 +191,7 @@ test('fromDirectory() resolves options, dependencies, uses cache, and can genera
 
   env.BABEL_ENV = 'foo'
   const envPluginIndex = path.join(dir, 'node_modules', 'env-plugin', 'index.js')
+  const pluginDefaultOptsIndex = path.join(dir, 'node_modules', 'plugin-default-opts', 'index.js')
   t.deepEqual(configModule.getOptions(), {
     plugins: [
       [
@@ -254,7 +255,8 @@ test('fromDirectory() resolves options, dependencies, uses cache, and can genera
                     {
                       label: 'plugin@babelrc.foo'
                     }
-                  ]
+                  ],
+                  pluginDefaultOptsIndex
                 ],
                 presets: [
                   [
@@ -303,6 +305,7 @@ test('fromConfig() resolves options, dependencies, uses cache, and can generate 
   const pluginIndex = path.join(dir, 'node_modules', 'plugin', 'index.js')
   const presetIndex = path.join(dir, 'node_modules', 'preset', 'index.js')
   const envPluginIndex = path.join(dir, 'node_modules', 'env-plugin', 'index.js')
+  const pluginDefaultOptsIndex = path.join(dir, 'node_modules', 'plugin-default-opts', 'index.js')
   t.deepEqual(configModule.getOptions(), {
     plugins: [
       [
@@ -448,7 +451,8 @@ test('fromConfig() resolves options, dependencies, uses cache, and can generate 
                     {
                       label: 'plugin@babelrc.foo'
                     }
-                  ]
+                  ],
+                  pluginDefaultOptsIndex
                 ],
                 presets: [
                   [

--- a/test/reduceChains.js
+++ b/test/reduceChains.js
@@ -54,7 +54,7 @@ const reduces = (t, defaultChain, envChains, expected) => {
     options: {
       parserOpts: { foo: 1 },
       plugins: [['./baz', {}], 'foo'],
-      presets: ['qux'],
+      presets: [['qux']],
       sourceMaps: false
     },
     source: '2'


### PR DESCRIPTION
Fixes #10.

Add an explicit test in `test/reduceChains.js`, and an implicit test through the `.babelrc` file that is used in `test/compare.js`.