### PR TITLE
Use safe-buffer to allow Node 4.0

### DIFF
--- a/lib/Verifier.js
+++ b/lib/Verifier.js
@@ -5,6 +5,7 @@ const path = require('path')
 
 const isEqual = require('lodash.isequal')
 const md5Hex = require('md5-hex')
+const SafeBuffer = require('safe-buffer').Buffer
 
 const currentEnv = require('./currentEnv')
 const hashDependencies = require('./hashDependencies')
@@ -134,7 +135,7 @@ class Verifier {
   }
 
   toBuffer () {
-    return Buffer.from(JSON.stringify({
+    return SafeBuffer.from(JSON.stringify({
       babelrcDir: this.babelrcDir,
       envNames: this.envNames,
       dependencies: this.dependencies,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4801,8 +4801,7 @@
     "safe-buffer": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
-      "dev": true
+      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
     },
     "semver": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=4.5"
+    "node": ">=4"
   },
   "scripts": {
     "lint": "as-i-preach",
@@ -43,7 +43,8 @@
     "md5-hex": "^2.0.0",
     "package-hash": "^2.0.0",
     "pkg-dir": "^2.0.0",
-    "resolve-from": "^3.0.0"
+    "resolve-from": "^3.0.0",
+    "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
     "@novemberborn/as-i-preach": "^9.0.0",

--- a/test/hashDependencies.js
+++ b/test/hashDependencies.js
@@ -4,6 +4,7 @@ import path from 'path'
 import test from 'ava'
 import md5Hex from 'md5-hex'
 import packageHash from 'package-hash'
+import { Buffer as SafeBuffer } from 'safe-buffer'
 
 import hashDependencies from '../lib/hashDependencies'
 import fixture from './helpers/fixture'
@@ -76,7 +77,7 @@ test('caches new hashes', async t => {
 
 test('can use a cache for file access', async t => {
   const filename = fixture('cached-access')
-  const contents = Buffer.from('cached')
+  const contents = SafeBuffer.from('cached')
   const cache = {
     files: new Map([[filename, Promise.resolve(contents)]])
   }

--- a/test/hashSources.js
+++ b/test/hashSources.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 
 import test from 'ava'
 import md5Hex from 'md5-hex'
+import { Buffer as SafeBuffer } from 'safe-buffer'
 
 import hashSources from '../lib/hashSources'
 import fixture from './helpers/fixture'
@@ -80,7 +81,7 @@ test('caches new hashes', async t => {
 
 test('can use a cache for file access', async t => {
   const source = fixture('cached-access')
-  const contents = Buffer.from('cached')
+  const contents = SafeBuffer.from('cached')
   const cache = {
     files: new Map([[source, Promise.resolve(contents)]])
   }


### PR DESCRIPTION
SafeBuffer is a polyfill that provides `.from` (among other new Buffer methods) when needed. Node 4x is still in pretty wide use and supported until 2018-04-01. I think it's worth attempting to support all of 4 especially if its not too much trouble.

I named the `Buffer.from` calls `SafeBuffer.from` to satisfy the linter's no-shadow settings. That's a shadow I might allow to keep the code cleaner.