### PR TITLE
Explicitly test with older Node.js 4 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - '8'
   - '6'
   - '4'
+  - '4.4.7'
 cache:
   directories:
     - $HOME/.npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -2346,30 +2346,10 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
     },
     "hullabaloo-config-manager": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.0.1.tgz",
-      "integrity": "sha1-xyvnuiSaZ8mba6PrH1WDf6AazY8=",
-      "dev": true,
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-          "dev": true
-        }
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.0.tgz",
+      "integrity": "sha512-Y73/Famlt4ZESK0x/qDhC/lmJ73A92kAIIDgvHgiQ+anSlf5nfdMMVaNrfFrh/X6R0BBjp3aE/bAYZdRtvVv6A==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.3",
@@ -4761,7 +4741,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
       "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        }
+      }
     },
     "resolve-from": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@novemberborn/as-i-preach": "^9.0.0",
-    "ava": "^0.19.0",
+    "ava": "^0.19.1",
     "babel-core": "^6.22.1",
     "fs-extra": "^3.0.0",
     "lodash.ismatch": "^4.4.0",


### PR DESCRIPTION
Test with 4.4.7, which requires safe-buffer to be used.

(Hush hush, but the tests are failing in Node.js 4.0.0, presumably
due to V8 bugs. I'm not sure whether this is purely in the tests or
if the source is also affected.)